### PR TITLE
ActionsでCypressを並列で走らせるのをやめる

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,8 +8,8 @@ jobs:
     # Also see warning here https://github.com/cypress-io/github-action#parallel
     strategy:
       fail-fast: false # https://github.com/cypress-io/github-action/issues/48
-      matrix:
-        containers: [1, 2] # Uses 2 parallel instances
+      # matrix:
+      #   containers: [1, 2] # Uses 2 parallel instances
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
たまに実行環境が並列プロセス通しで違うと言われてエラーになるため