### PR TITLE
fix(ci): Chromatic CIのNodeバージョンを22.16.0に更新

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.12.0
+          node-version: 22.16.0
       - name: Install dependencies
         # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
         run: yarn


### PR DESCRIPTION
## Summary
- Chromatic CIのNodeバージョンを `22.12.0` → `22.16.0` に更新
- `eslint-visitor-keys@5.0.1` が `^22.13.0` 以上を要求するため、22.12.0ではyarn installが失敗する問題を修正
- Volta設定（ローカル開発環境）と同じバージョンに統一

## Background
PR #1391 等のCIが以下のエラーで失敗している:
```
error eslint-visitor-keys@5.0.1: The engine "node" is incompatible with this module. Expected version "^20.19.0 || ^22.13.0 || >=24". Got "22.12.0"
```

## Test plan
- [ ] Chromatic CIが正常にパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)