### PR TITLE
fix(notion): Notion API v2025-09-03 (dataSources分離) に対応

### DIFF
--- a/components/Molecules/About/WorkExperience.tsx
+++ b/components/Molecules/About/WorkExperience.tsx
@@ -30,8 +30,9 @@ export const WorkExperience = ({
             key={genre.id}
             genre={genre}
             works={workExperience.filter((work) => {
-              const genreId = getProperties(work, { name: 'genre', type: 'relation' }).id
-              return genreId === genre.id
+              // Why: relation が空の場合 getProperties は undefined を返すため optional chaining で安全にアクセス
+              const genreRelation = getProperties(work, { name: 'genre', type: 'relation' })
+              return genreRelation?.id === genre.id
             })}
           />
         ))}

--- a/libs/@type/api/notion.d.ts
+++ b/libs/@type/api/notion.d.ts
@@ -1,6 +1,9 @@
 import type { Client } from '@notionhq/client'
 
-export type PageObject = ElementType<Awaited<ReturnType<Client['databases']['query']>>['results']>
+// Why: Notion API v2025-09-03 で dataSources.query() に移行
+// dataSources.query() の results は PageObject | DataSourceObject のユニオン型だが、
+// ページクエリでは PageObject のみ返されるため、従来通りの型を維持
+export type PageObject = ElementType<Awaited<ReturnType<Client['dataSources']['query']>>['results']>
 
 export type BlockObject = ElementType<
   Awaited<ReturnType<Client['blocks']['children']['list']>>['results']

--- a/libs/notion.ts
+++ b/libs/notion.ts
@@ -1,9 +1,21 @@
 import { Client } from '@notionhq/client'
 
-import type { QueryDatabaseParameters } from '@notionhq/client/build/src/api-endpoints'
+import type { QueryDataSourceParameters } from '@notionhq/client/build/src/api-endpoints'
 import type { PageObject, propertiesTypes } from 'libs/@type/api/notion'
 
 const notion = new Client({ auth: process.env.NEXT_PUBLIC_NOTION_TOKEN })
+
+// Why: Notion API v2025-09-03 で database と data_source が分離された
+// database_id から data_source_id を解決するヘルパー
+// Trade-off: ビルド時に1DB毎に追加APIコールが発生するが、getStaticPropsのみで使用するため許容範囲
+const resolveDataSourceId = async (databaseId: string): Promise<string> => {
+  const database = await notion.databases.retrieve({ database_id: databaseId })
+  if (!('data_sources' in database) || database.data_sources.length === 0) {
+    throw new Error(`Database ${databaseId} has no data sources`)
+  }
+  return database.data_sources[0].id
+}
+
 type getDatabaseOptions = {
   sortProperty?: string
   sortDirection?: 'ascending' | 'descending'
@@ -12,8 +24,10 @@ export const getDatabase = async (
   databaseId: string,
   { sortProperty, sortDirection = 'descending' }: getDatabaseOptions = {}
 ) => {
+  const dataSourceId = await resolveDataSourceId(databaseId)
+
   //オプションでソート順を指定できる
-  const sorts: QueryDatabaseParameters['sorts'] = sortProperty
+  const sorts: QueryDataSourceParameters['sorts'] = sortProperty
     ? [
         {
           property: sortProperty || '',
@@ -27,8 +41,8 @@ export const getDatabase = async (
         },
       ]
 
-  const response = await notion.databases.query({
-    database_id: databaseId,
+  const response = await notion.dataSources.query({
+    data_source_id: dataSourceId,
     sorts: sorts,
   })
   return response.results

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@emotion/is-prop-valid": "^1.4.0",
     "@formspree/react": "^2.5.1",
     "@headlessui/react": "^1.7.17",
-    "@notionhq/client": "^3.1.3",
+    "@notionhq/client": "^5.12.0",
     "@radix-ui/react-label": "^2.0.1",
     "@radix-ui/react-separator": "^1.0.2",
     "@vercel/analytics": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,10 +3282,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@notionhq/client@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "@notionhq/client@npm:3.1.3"
-  checksum: f599cd656037784125bb84963b0a4549c100223659d193c03b60bd2721fd302589bd12163e914b8fc5770dd753e4cad7eeec5bd2d231b9c227470312412eb4e8
+"@notionhq/client@npm:^5.12.0":
+  version: 5.12.0
+  resolution: "@notionhq/client@npm:5.12.0"
+  checksum: d286c9d858f6af7c91a8dbeb31042784dd0e9d68b9338aa23d51aeb89eef62bc8f5a1d8c3b0d1423081fc4e8c441120b71554d9f6d9ef8b464cb46fbadebd328
   languageName: node
   linkType: hard
 
@@ -11826,7 +11826,7 @@ __metadata:
     "@eslint/js": "npm:^9.11.1"
     "@formspree/react": "npm:^2.5.1"
     "@headlessui/react": "npm:^1.7.17"
-    "@notionhq/client": "npm:^3.1.3"
+    "@notionhq/client": "npm:^5.12.0"
     "@playwright/test": "npm:^1.40.1"
     "@radix-ui/react-label": "npm:^2.0.1"
     "@radix-ui/react-separator": "npm:^1.0.2"


### PR DESCRIPTION
## Summary
- `@notionhq/client` を v3.1.3 → v5.12.0 にアップグレード
- Notion API v2025-09-03 の破壊的変更（database と data_source の分離）に対応
- `databases.query()` → `dataSources.query()` に移行
- database_id → data_source_id のランタイム自動解決ヘルパーを追加
- WorkExperience の relation プロパティアクセスを安全化

## Why
Notion からの通知メールにて、API v2025-09-03 で database と data_source が分離される破壊的変更が告知された。
ユーザーが database に新しい data source を追加した場合、旧 API を使用しているとクエリ・ページ作成・更新が失敗する。

## 変更ファイル
- `package.json` / `yarn.lock` - SDK アップグレード
- `libs/notion.ts` - dataSources.query() への移行 + resolveDataSourceId ヘルパー追加
- `libs/@type/api/notion.d.ts` - 型定義を dataSources.query() レスポンス型に更新
- `components/Molecules/About/WorkExperience.tsx` - relation アクセスの安全化

## Test plan
- [x] `yarn lint` パス
- [x] `npx tsc --noEmit` パス
- [x] `yarn build` パス（全ページ正常に静的生成）
- [x] Chromatic CI パス
- [ ] Vercel プレビューデプロイで /about, /contact ページの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)