### PR TITLE
fix(vercel): Yarn 4でのinstallCommand修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,5 @@
   "cleanUrls": true,
   "devCommand": "yarn dev",
   "framework": "nextjs",
-  "installCommand": "corepack enable && yarn install"
+  "installCommand": "corepack yarn install"
 }


### PR DESCRIPTION
## Summary
Vercel デプロイで Yarn 4 が確実に使用されるよう installCommand を修正しました。

## Changes
- `vercel.json` の `installCommand` を `"corepack yarn install"` に変更
- 前の `"corepack enable && yarn install"` では Vercel 環境の PATH で `/usr/bin/yarn`（v1）が優先されてしまい、Yarn 1 が起動していました
- `corepack yarn install` は corepack が直接 `packageManager` フィールドを読んで Yarn 4 を起動するため、PATH に依存しません

## Related Issues
- Vercel deployment failures with `minimatch` scoped resolutions error
- Yarn 4 requires scoped resolution syntax incompatible with Yarn 1

## Test Plan
- [ ] Vercel Preview deployment uses `yarn install v4.0.2`
- [ ] Deployment succeeds without minimatch resolution errors
- [ ] Production deployment (master) also works correctly