### PR TITLE
test(scroll): ページ遷移スクロール位置の回帰テスト追加

### DIFF
--- a/components/Atoms/ContentsWrapper.tsx
+++ b/components/Atoms/ContentsWrapper.tsx
@@ -22,9 +22,8 @@ export const ContentsWrapper = ({
 
   const ref = useRef<HTMLElement>(null)
   const setContentsWrapper = useSetAtom(contentsWrapperState)
-  // Why: onExitComplete発火時にはAnimatePresenceが古いmotion.sectionをアンマウント済みで
-  // refが無効になる場合がある。requestAnimationFrameで1フレーム待つことで、
-  // 新しいmotion.sectionがマウントされrefが有効になった後にスクロールする。
+  // Why: 初回マウント時のみ `setTimeout(scrollIntoView)` を実行するためのガード。
+  // 2回目以降のエフェクト実行時には、自動スクロールを抑止する意図。
   const isInitialMount = useRef(true)
 
   useEffect(() => {

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -30,3 +30,58 @@ describe('トップページにアクセスしたとき', () => {
     cy.url().should('not.include', '/ja')
   })
 })
+
+// ページ遷移時のスクロール位置
+// Why: Contact→About遷移時にスクロール位置がページ途中に残るバグ(#100)の回帰防止
+// scrollIntoView(true)はContentsWrapperのoffsetTop位置にスクロールするため、
+// window.scrollYがContentsWrapperのoffsetTop付近(±50px)であることを検証する
+describe('ページ遷移時のスクロール位置', () => {
+  /**
+   * ContentsWrapperのoffsetTopを取得し、scrollYがその付近にあるかを検証する。
+   * scrollIntoView(true)はContentsWrapperの上端にビューポート上端を合わせるため、
+   * scrollY ≈ offsetTop になるのが正常。
+   */
+  const assertScrolledToContentsWrapper = () => {
+    cy.window().then((win) => {
+      const contentsWrapper = win.document.querySelector('section.relative')
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- Chaiのexpression style assertion
+      expect(contentsWrapper).to.not.be.null
+      const offsetTop = (contentsWrapper as HTMLElement).offsetTop
+      const tolerance = 50
+      // scrollYがContentsWrapperのoffsetTop付近にあること
+      expect(win.scrollY).to.be.greaterThan(offsetTop - tolerance)
+      expect(win.scrollY).to.be.lessThan(offsetTop + tolerance)
+    })
+  }
+
+  it('Contact→About遷移後にコンテンツ先頭付近にスクロールされる', () => {
+    // Contactページに遷移
+    cy.visit('/contact')
+    cy.url().should('include', '/contact')
+
+    // Aboutナビリンクをクリック（ヘッダー・フッター両方にNavLinksがあるため.first()）
+    cy.get('[data-testid="nav-link-/about"]').first().click()
+    cy.url().should('include', '/about')
+
+    // AnimatePresenceのトランジション完了を待つ
+    // (exit 0.2s + enter 0.2s + requestAnimationFrame)
+    cy.wait(800)
+
+    assertScrolledToContentsWrapper()
+  })
+
+  it('Works(トップ)→About遷移後にコンテンツ先頭付近にスクロールされる', () => {
+    cy.visit('/')
+
+    // トップでスクロールを下げておく（長いページの場合）
+    cy.scrollTo(0, 500)
+
+    // Aboutナビリンクをクリック
+    cy.get('[data-testid="nav-link-/about"]').first().click()
+    cy.url().should('include', '/about')
+
+    cy.wait(800)
+
+    assertScrolledToContentsWrapper()
+  })
+})


### PR DESCRIPTION
## Summary
- #100 (Contact→Aboutスクロール位置バグ) の回帰防止テストを Cypress e2e に追加
- `isInitialMount` のWhyコメントが `onExitComplete`/`requestAnimationFrame` の説明になっていた問題を修正（Copilotレビュー指摘対応）

## 変更内容
### Cypress e2eテスト (`cypress/e2e/spec.cy.ts`)
- **Contact→About遷移テスト**: Contact訪問→Aboutナビクリック→トランジション待機→`scrollY ≈ ContentsWrapper.offsetTop` を検証
- **Works→About遷移テスト**: トップでスクロール下げ→Aboutナビクリック→同様の検証

### コメント修正 (`components/Atoms/ContentsWrapper.tsx`)
- `isInitialMount` 上のWhyコメントを実際の用途（初回マウント時のsetTimeoutガード）に合わせて修正

## Test plan
- [x] Cypress e2eテスト 5/5 passing (`npx cypress run --browser chrome`)
- [x] ESLint通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)