### PR TITLE
ci: カバレッジバッジを CI から自動更新する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,13 @@ jobs:
         # components/ のカバレッジは Storybook テスト経由でローカルで確認する運用。
         run: yarn vitest run --project=unit --coverage
 
+      - name: Extract coverage percentage
+        # Why: coverage-summary.json から lines カバレッジを取り出し、後続ステップで使う
+        id: coverage
+        run: |
+          LINES=$(node -e "const c=require('./coverage/coverage-summary.json');console.log(c.total.lines.pct)")
+          echo "lines=$LINES" >> "$GITHUB_OUTPUT"
+
       - name: Report coverage to PR
         # Why: PR のときだけカバレッジレポートを投稿する。
         # push イベント時はスキップされるため pull-requests: write は実質使われない。
@@ -47,3 +54,18 @@ jobs:
         with:
           json-summary-path: ./coverage/coverage-summary.json
           json-final-path: ./coverage/coverage-final.json
+
+      - name: Update coverage badge
+        # Why: master push 時のみ Gist のバッジ JSON を更新する。
+        # PR 時はバッジ更新不要（マージされるまで master のカバレッジは変わらない）。
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: 8124a9e2d8ac31a6b86923d4fe80dae9
+          filename: coverage-badge.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.lines }}%
+          valColorRange: ${{ steps.coverage.outputs.lines }}
+          minColorRange: 0
+          maxColorRange: 100

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mieze illustration — portfolio v2
 
 [![Test & Coverage](https://github.com/mieze018/portfolio-v2/actions/workflows/test.yml/badge.svg)](https://github.com/mieze018/portfolio-v2/actions/workflows/test.yml)
-![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
+![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/mieze018/8124a9e2d8ac31a6b86923d4fe80dae9/raw/coverage-badge.json)
 
 Portfolio site of Ayu Nakata, an Osaka, Japan-based artist & illustrator.


### PR DESCRIPTION
## Summary
Closes #1430

- master push 時に `coverage-summary.json` から lines カバレッジ % を抽出
- `schneegans/dynamic-badges-action` で Gist の badge JSON を自動更新
- README のバッジを shields.io endpoint 形式に切り替え（Gist 参照）

### 仕組み
```
master push → テスト実行 → coverage 抽出 → Gist 更新 → shields.io が自動反映
```

## Test plan
- [x] PR の CI でテストが通ること
- [ ] マージ後、master push で Gist が更新されること
- [ ] README のバッジにカバレッジ % が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)